### PR TITLE
feat: 初始化 Vue2 + Router + ECharts 示例并移除占位文件

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ['@vue/cli-plugin-babel/preset']
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "demo",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "serve": "vue-cli-service serve",
+    "build": "vue-cli-service build"
+  },
+  "dependencies": {
+    "core-js": "^3.38.1",
+    "echarts": "^5.5.1",
+    "vue": "^2.7.16",
+    "vue-router": "^3.6.5"
+  },
+  "devDependencies": {
+    "@vue/cli-service": "^5.0.8",
+    "vue-template-compiler": "^2.7.16",
+    "@vue/cli-plugin-babel": "^5.0.8"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+    <title>Vue2 Router ECharts Demo</title>
+  </head>
+  <body>
+    <noscript>
+      <strong>We're sorry but this app doesn't work properly without JavaScript enabled.</strong>
+    </noscript>
+    <div id="app"></div>
+  </body>
+</html>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,0 +1,41 @@
+<template>
+  <div id="app">
+    <header class="header">
+      <h1>Vue2 + Router + ECharts</h1>
+      <nav>
+        <router-link to="/">首页</router-link>
+        <router-link to="/chart">图表示例</router-link>
+      </nav>
+    </header>
+    <main>
+      <router-view />
+    </main>
+  </div>
+</template>
+
+<style scoped>
+#app {
+  font-family: Avenir, Helvetica, Arial, sans-serif;
+  color: #2c3e50;
+  margin: 0 auto;
+  max-width: 960px;
+  padding: 20px;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24px;
+}
+
+nav a {
+  margin-left: 16px;
+  color: #409eff;
+  text-decoration: none;
+}
+
+nav a.router-link-exact-active {
+  font-weight: bold;
+}
+</style>

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,10 @@
+import Vue from 'vue'
+import App from './App.vue'
+import router from './router'
+
+Vue.config.productionTip = false
+
+new Vue({
+  router,
+  render: (h) => h(App)
+}).$mount('#app')

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,0 +1,22 @@
+import Vue from 'vue'
+import Router from 'vue-router'
+import HomeView from '../views/HomeView.vue'
+import ChartView from '../views/ChartView.vue'
+
+Vue.use(Router)
+
+export default new Router({
+  mode: 'hash',
+  routes: [
+    {
+      path: '/',
+      name: 'home',
+      component: HomeView
+    },
+    {
+      path: '/chart',
+      name: 'chart',
+      component: ChartView
+    }
+  ]
+})

--- a/src/views/ChartView.vue
+++ b/src/views/ChartView.vue
@@ -1,0 +1,69 @@
+<template>
+  <section>
+    <h2>月度销售图</h2>
+    <div ref="chart" class="chart"></div>
+  </section>
+</template>
+
+<script>
+import * as echarts from 'echarts'
+
+export default {
+  name: 'ChartView',
+  data() {
+    return {
+      chart: null
+    }
+  },
+  mounted() {
+    this.initChart()
+    window.addEventListener('resize', this.handleResize)
+  },
+  beforeDestroy() {
+    window.removeEventListener('resize', this.handleResize)
+    if (this.chart) {
+      this.chart.dispose()
+      this.chart = null
+    }
+  },
+  methods: {
+    initChart() {
+      this.chart = echarts.init(this.$refs.chart)
+      this.chart.setOption({
+        tooltip: {},
+        xAxis: {
+          type: 'category',
+          data: ['1月', '2月', '3月', '4月', '5月', '6月']
+        },
+        yAxis: {
+          type: 'value'
+        },
+        series: [
+          {
+            name: '销售额',
+            type: 'bar',
+            data: [120, 200, 150, 80, 70, 110],
+            itemStyle: {
+              color: '#409EFF'
+            }
+          }
+        ]
+      })
+    },
+    handleResize() {
+      if (this.chart) {
+        this.chart.resize()
+      }
+    }
+  }
+}
+</script>
+
+<style scoped>
+.chart {
+  width: 100%;
+  height: 420px;
+  border: 1px solid #ebeef5;
+  border-radius: 8px;
+}
+</style>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -1,0 +1,7 @@
+<template>
+  <section>
+    <h2>欢迎</h2>
+    <p>这是一个 Vue2 + Vue Router + ECharts 的演示项目。</p>
+    <p>点击上方“图表示例”查看柱状图。</p>
+  </section>
+</template>


### PR DESCRIPTION
### Motivation
- 需要将仓库从占位状态清理并搭建一个可开发的前端骨架以便后续开发和演示。

### Description
- 删除占位文件 `(.gitkeep)` 并新增基于 Vue 2 的项目骨架，包括入口与页面文件。 
- 新增项目配置文件 `package.json` 和 `babel.config.js`，并在 `package.json` 中声明了 `vue`、`vue-router`、`echarts` 等依赖以及 `serve`/`build` 脚本。 
- 新增应用入口 `src/main.js`、主组件 `src/App.vue`、路由配置 `src/router/index.js` 以及两个视图 `src/views/HomeView.vue` 与 `src/views/ChartView.vue`。 
- 在 `src/views/ChartView.vue` 中使用 `echarts` 初始化柱状图并实现窗口 `resize` 自适应与实例销毁时的释放。 

### Testing
- 运行 `npm install` 以安装依赖但在当前环境中访问 npm registry 返回 `403 Forbidden`，导致安装失败。 
- 运行 `npm install --registry=https://registry.npmmirror.com` 同样返回 `403 Forbidden`，依赖仍未能安装。 
- 运行基于 Playwright 的脚本尝试访问 `http://127.0.0.1:8080` 并截图时因服务未启动返回 `ERR_EMPTY_RESPONSE`，截图操作失败。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6a211f6ac832794d9fb2e38646a8c)